### PR TITLE
Implement GridSearchCV tuning

### DIFF
--- a/load.py
+++ b/load.py
@@ -1,6 +1,6 @@
 import re
 import pandas as pd
-from sklearn.model_selection import train_test_split
+from sklearn.model_selection import train_test_split, GridSearchCV
 from sklearn.pipeline import Pipeline
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.linear_model import LogisticRegression
@@ -30,13 +30,22 @@ X_train, X_test, y_train, y_test = train_test_split(
 )
 
 pipeline = Pipeline([
-    ("tfidf", TfidfVectorizer(ngram_range=(1,2), max_df=0.9)),
-    ("clf", LogisticRegression(solver="liblinear", C=1.0)),
+    ("tfidf", TfidfVectorizer()),
+    ("clf", LogisticRegression(solver="liblinear", max_iter=1000)),
 ])
 
-pipeline.fit(X_train, y_train)
+param_grid = {
+    "tfidf__ngram_range": [(1, 1), (1, 2)],
+    "tfidf__max_df": [0.75, 0.9],
+    "clf__C": [0.1, 1.0, 10.0],
+}
 
-y_pred = pipeline.predict(X_test)
+grid = GridSearchCV(pipeline, param_grid, cv=5, n_jobs=-1, verbose=1)
+grid.fit(X_train, y_train)
+
+print("Best parameters:", grid.best_params_)
+
+y_pred = grid.predict(X_test)
 print("Classification Report:\n", classification_report(y_test, y_pred))
 print("Confusion Matrix:\n", confusion_matrix(y_test, y_pred))
 


### PR DESCRIPTION
## Summary
- tune `TfidfVectorizer` and `LogisticRegression` using `GridSearchCV`
- show best parameters and evaluate on the test split

## Testing
- `python3 load.py` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6866ad72a8bc8324bf1049db41283bcb