### PR TITLE
Add dependency check for transformer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ EPC - testing only.
 
 A new script `transformer_train.py` uses Hugging Face's `transformers` library to train a `DistilBERT` model on the questions dataset. The workflow mirrors `load.py` but leverages a pretrained transformer and `Trainer` for fine-tuning.
 
+`transformer_train.py` depends on PyTorch and Accelerate. Install them with:
+
+```bash
+pip install transformers[torch] 'accelerate>=0.26.0'
+```
+
 Run it with:
 
 ```bash

--- a/transformer_train.py
+++ b/transformer_train.py
@@ -5,6 +5,15 @@ model using Hugging Face ``transformers``. It expects ``pandas``, ``scikit-learn
 ``datasets`` and ``torch`` to be installed.
 """
 
+try:  # Ensure PyTorch and Accelerate are available for Trainer
+    import torch  # noqa: F401
+    import accelerate  # noqa: F401
+except ImportError as e:  # pragma: no cover - simple availability check
+    raise ImportError(
+        "Trainer requires PyTorch and Accelerate. Install them via "
+        "`pip install transformers[torch]` or `pip install 'accelerate>=0.26.0'`."
+    ) from e
+
 import re
 from typing import Dict
 


### PR DESCRIPTION
## Summary
- require PyTorch and Accelerate when running `transformer_train.py`
- document transformer dependencies and install command in README

## Testing
- `python -m py_compile transformer_train.py load.py`

------
https://chatgpt.com/codex/tasks/task_e_686e88cf873c8324ad172ecfaccc597b